### PR TITLE
Query strings format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Added
 ### Changed
+- feat(#6): Use [query-string](https://www.npmjs.com/package/query-string) package to format query strings. Allow configuring query-string options using the `queryStringFormat` option of this package. This is a BREAKING CHANGE because query-string default options are used (read BREAKING CHANGES bellow for further info)
 ### Fixed
 ### Removed
 ### BREAKING CHANGES
+- Arrays in query strings were converted into a list separated by "%2C" (url encoded comma). Now it uses the `arrayFormat` `none` by default, so arrays are serialized duplicating keys, but it can be configured using the new `queryStringFormat` option.
+- query string keys now are sorted by default.
 
 ## [3.1.0] - 2021-06-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Added
 ### Changed
-- feat(#6): Use [query-string](https://www.npmjs.com/package/query-string) package to format query strings. Allow configuring query-string options using the `queryStringFormat` option of this package. This is a BREAKING CHANGE because query-string default options are used (read BREAKING CHANGES bellow for further info)
+- feat(#6): Use [query-string](https://www.npmjs.com/package/query-string) package to format query strings. Allow configuring query-string options using the `queryStringConfig` option of this package. This is a BREAKING CHANGE because query-string default options are used (read BREAKING CHANGES bellow for further info)
 ### Fixed
 ### Removed
 ### BREAKING CHANGES
-- Arrays in query strings were converted into a list separated by "%2C" (url encoded comma). Now it uses the `arrayFormat` `none` by default, so arrays are serialized duplicating keys, but it can be configured using the new `queryStringFormat` option.
+- Arrays in query strings were converted into a list separated by "%2C" (url encoded comma). Now it uses the `arrayFormat` `none` by default, so arrays are serialized duplicating keys, but it can be configured using the new `queryStringConfig` option.
 - query string keys now are sorted by default.
 
 ## [3.1.0] - 2021-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 ### BREAKING CHANGES
-- Arrays in query strings were converted into a list separated by "%2C" (url encoded comma). Now it uses the `arrayFormat` `none` by default, so arrays are serialized duplicating keys, but it can be configured using the new `queryStringConfig` option.
+- Arrays in query strings were converted into a list separated by "%2C" (url encoded comma). Now it uses the `query-string` package using its default options, so arrays are serialized duplicating keys (`?foo=1&foo=2`). This behaviour can be configured using the new `queryStringConfig` option.
 - query string keys now are sorted by default.
 
 ## [3.1.0] - 2021-06-18

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Apart of the common Data Provider options, next ones are available:
 		* `error` _(Error)_: Error object produced by a failed request.
 	* Returns: Should return a rejected Promise, containing the new Error.
 * `axiosConfig` _(Object)_: Options for the Axios request. If provided, this object is passed directly to Axios as [request configuration](https://github.com/axios/axios#request-config).
+* `queryStringConfig` _(Object)_: Options for the [query-string library](https://github.com/sindresorhus/query-string#readme), which is used under the hood to serialize query string parameters. If provided, this object is passed directly to `query-string` as [options for the `stringify` method](https://github.com/sindresorhus/query-string#stringifyobject-options). Default options are the same from the library.
 
 ## Queries
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/**/?(*.)+(spec|test).js?(x)"],
-  testMatch: ["<rootDir>/test/queries.spec.js"],
+  // testMatch: ["<rootDir>/test/methods.spec.js"],
 
   transform: {
     ".js$": "babel-jest",

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,7 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["**/test/**/?(*.)+(spec|test).js?(x)"],
-  // testMatch: ["<rootDir>/test/methods.spec.js"],
+  testMatch: ["<rootDir>/test/queries.spec.js"],
 
   transform: {
     ".js$": "babel-jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5123,6 +5123,11 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -5884,6 +5889,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -9328,6 +9338,17 @@
         "side-channel": "^1.0.4"
       }
     },
+    "query-string": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9842,6 +9863,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9994,6 +10020,11 @@
           "dev": true
         }
       }
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-argv": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "axios": "0.21.1",
     "axios-retry": "3.1.9",
+    "query-string": "7.0.1",
     "path-to-regexp": "6.2.0"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,7 @@ const BASE_PLUGINS = [
 
 const BASE_CONFIG = {
   input: "src/index.js",
-  external: ["@data-provider/core", "axios", "axios-retry", "path-to-regexp"],
+  external: ["@data-provider/core", "axios", "axios-retry", "path-to-regexp", "query-string"],
   plugins: [...BASE_PLUGINS, terser()],
 };
 
@@ -42,6 +42,7 @@ const GLOBALS = {
   axios: "axios",
   "axios-retry": "axiosRetry",
   "path-to-regexp": "pathToRegexp",
+  "query-string": "queryString",
 };
 
 module.exports = [

--- a/src/Axios.js
+++ b/src/Axios.js
@@ -13,6 +13,7 @@ import { Provider } from "@data-provider/core";
 import { compile } from "path-to-regexp";
 import axios from "axios";
 import axiosRetry from "axios-retry";
+import queryString from "query-string";
 
 import {
   once,
@@ -54,7 +55,8 @@ export class Axios extends Provider {
     this._baseUrl = configuration.baseUrl;
     this._onBeforeRequest = configuration.onBeforeRequest;
     this._url = configuration.url;
-    this._axiosConfig = configuration.axiosConfig || {};
+    this._axiosConfig = configuration.axiosConfig;
+    this._queryStringConfig = configuration.queryStringConfig;
 
     if (configuration.retries !== this._retries) {
       this._retries = configuration.retries;
@@ -78,27 +80,22 @@ export class Axios extends Provider {
     this._setUrl(this._baseUrl + this._url);
   }
 
-  _getQueryString(queryString) {
-    if (!queryString || isEmpty(queryString)) {
+  _getQueryString(queryStringValue) {
+    if (!queryStringValue || isEmpty(queryStringValue)) {
       return "";
     }
-    return (
-      "?" +
-      Object.keys(queryString)
-        .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(queryString[key])}`)
-        .join("&")
-    );
+    return `?${queryString.stringify(queryStringValue, this._queryStringConfig)}`;
   }
 
   _getUrl() {
-    const queryString = this.queryValue.queryString;
+    const queryStringValue = this.queryValue.queryString;
     const urlParams = this.queryValue.urlParams;
     if (urlParams && !isEmpty(urlParams)) {
       return `${this.url.base}/${this.url.segment(urlParams)}${
         this.url.trailingSlash
-      }${this._getQueryString(queryString)}`;
+      }${this._getQueryString(queryStringValue)}`;
     }
-    return `${this.url.full}${this._getQueryString(queryString)}`;
+    return `${this.url.full}${this._getQueryString(queryStringValue)}`;
   }
 
   _setUrl(fullUrl) {

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -32,4 +32,6 @@ export const defaultConfig = {
     errorToReturn.data = error.response && error.response.data;
     return Promise.reject(errorToReturn);
   },
+  axiosConfig: {},
+  queryStringConfig: {},
 };

--- a/test/custom-queries.spec.js
+++ b/test/custom-queries.spec.js
@@ -164,7 +164,7 @@ describe("Axios queries", () => {
         });
       await queriedBooks.read();
       expect(axios.stubs.instance.getCall(0).args[0].url).toEqual(
-        "/books/foo/cervantes?page=2&order=asc"
+        "/books/foo/cervantes?order=asc&page=2"
       );
     });
 
@@ -188,7 +188,7 @@ describe("Axios queries", () => {
         });
       await queriedBooks.read();
       expect(axios.stubs.instance.getCall(0).args[0].url).toEqual(
-        "https://www.domain.com:3000/books/foo/cervantes?page=2&order=asc"
+        "https://www.domain.com:3000/books/foo/cervantes?order=asc&page=2"
       );
     });
   });

--- a/test/queries.spec.js
+++ b/test/queries.spec.js
@@ -45,7 +45,7 @@ describe("Axios queries", () => {
     });
   });
 
-  describe("Queried providers", () => {
+  describe.only("Queried providers", () => {
     it("should add query params to axios request", async () => {
       axios.stubs.instance.resetHistory();
       const books = new Axios({
@@ -57,6 +57,21 @@ describe("Axios queries", () => {
       });
       await books.read();
       expect(axios.stubs.instance.getCall(0).args[0].url).toEqual("/books?author=foo");
+    });
+
+    it("should add query params to axios request as comma separated list when it is an array", async () => {
+      axios.stubs.instance.resetHistory();
+      const books = new Axios({
+        url: "/books",
+      }).query({
+        queryString: {
+          authors: ["foo", "foo2", "foo3"],
+        },
+      });
+      await books.read();
+      expect(axios.stubs.instance.getCall(0).args[0].url).toEqual(
+        "/books?authors=foo%2Cfoo2%2Cfoo3"
+      );
     });
 
     it("should add query params to axios request when url includes protocol", async () => {

--- a/test/queries.spec.js
+++ b/test/queries.spec.js
@@ -45,7 +45,7 @@ describe("Axios queries", () => {
     });
   });
 
-  describe.only("Queried providers", () => {
+  describe("Queried providers", () => {
     it("should add query params to axios request", async () => {
       axios.stubs.instance.resetHistory();
       const books = new Axios({
@@ -59,7 +59,7 @@ describe("Axios queries", () => {
       expect(axios.stubs.instance.getCall(0).args[0].url).toEqual("/books?author=foo");
     });
 
-    it("should add query params to axios request as comma separated list when it is an array", async () => {
+    it("should add query params to axios request as duplicated keys", async () => {
       axios.stubs.instance.resetHistory();
       const books = new Axios({
         url: "/books",
@@ -70,7 +70,7 @@ describe("Axios queries", () => {
       });
       await books.read();
       expect(axios.stubs.instance.getCall(0).args[0].url).toEqual(
-        "/books?authors=foo%2Cfoo2%2Cfoo3"
+        "/books?authors=foo&authors=foo2&authors=foo3"
       );
     });
 
@@ -176,7 +176,7 @@ describe("Axios queries", () => {
       });
       await books.read();
       expect(axios.stubs.instance.getCall(0).args[0].url).toEqual(
-        "/books/foo/cervantes?page=2&order=asc"
+        "/books/foo/cervantes?order=asc&page=2"
       );
     });
 
@@ -196,8 +196,26 @@ describe("Axios queries", () => {
       });
       await books.read();
       expect(axios.stubs.instance.getCall(0).args[0].url).toEqual(
-        "https://www.domain.com:3000/books/foo/cervantes?page=2&order=asc"
+        "https://www.domain.com:3000/books/foo/cervantes?order=asc&page=2"
       );
+    });
+  });
+
+  describe("queryStringConfig option", () => {
+    it('when arrayFormat option is "comma", it should add query params to axios request as comma separated list', async () => {
+      axios.stubs.instance.resetHistory();
+      const books = new Axios({
+        url: "/books",
+        queryStringConfig: {
+          arrayFormat: "comma",
+        },
+      }).query({
+        queryString: {
+          authors: ["foo", "foo2", "foo3"],
+        },
+      });
+      await books.read();
+      expect(axios.stubs.instance.getCall(0).args[0].url).toEqual("/books?authors=foo,foo2,foo3");
     });
   });
 


### PR DESCRIPTION
### Changed
- feat(#6): Use [query-string](https://www.npmjs.com/package/query-string) package to format query strings. Allow configuring query-string options using the `queryStringConfig` option of this package. This is a BREAKING CHANGE because query-string default options are used (read BREAKING CHANGES bellow for further info)

### BREAKING CHANGES
- Arrays in query strings were converted into a list separated by "%2C" (url encoded comma). Now it uses the `query-string` package using its default options, so arrays are serialized duplicating keys (`?foo=1&foo=2`). This behaviour can be configured using the new `queryStringConfig` option.
- query string keys now are sorted by default.